### PR TITLE
Feature/permission management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 dist/
 .idea/
 .vscode/
+.cache/
 
 .clang-format
 .clang-tidy

--- a/src/cache/cache_manager.hpp
+++ b/src/cache/cache_manager.hpp
@@ -101,6 +101,10 @@ class CacheManager
 
     StorageResult<struct statvfs> GetFilesystemStats(fs::path& fuse_path);
 
+    StorageResult<void> SetPermissions(const fs::path& fuse_path, mode_t mode);
+
+    StorageResult<void> SetOwner(const fs::path& fuse_path, uid_t uid, gid_t gid);
+
     //------------------------------------------------------------------------------//
     // Public Fields
     //------------------------------------------------------------------------------//

--- a/src/cache/cache_tier.cpp
+++ b/src/cache/cache_tier.cpp
@@ -324,6 +324,40 @@ StorageResult<struct stat> CacheTier::GetAttributes(const std::filesystem::path 
         );
     return result;
 }
+StorageResult<void> CacheTier::SetPermissions(const fs::path &relative_path, mode_t mode)
+{
+    std::lock_guard lock(cache_mutex_);
+    spdlog::debug(
+        "CacheTier::SetPermissions(tier={}, {}, {:o})", cache_definition_.tier,
+        relative_path.string(), mode
+    );
+    auto result = storage_instance_->SetPermissions(relative_path, mode);
+    if (result)
+        spdlog::trace("CacheTier::SetPermissions(tier={}) -> Success");
+    else
+        spdlog::trace(
+            "CacheTier::SetPermissions(tier={}) -> Error: {}", cache_definition_.tier,
+            result.error().message()
+        );
+    return result;
+}
+StorageResult<void> CacheTier::SetOwner(const fs::path &relative_path, uid_t uid, gid_t gid)
+{
+    std::lock_guard lock(cache_mutex_);
+    spdlog::debug(
+        "CacheTier::SetOwner(tier={}, {}, {}, {})", cache_definition_.tier, relative_path.string(),
+        uid, gid
+    );
+    auto result = storage_instance_->SetOwner(relative_path, uid, gid);
+    if (result)
+        spdlog::trace("CacheTier::SetOwner(tier={}) -> Success");
+    else
+        spdlog::trace(
+            "CacheTier::SetOwner(tier={}) -> Error: {}", cache_definition_.tier,
+            result.error().message()
+        );
+    return result;
+}
 StorageResult<void> CacheTier::Initialize()
 {
     std::lock_guard lock(cache_mutex_);

--- a/src/cache/cache_tier.hpp
+++ b/src/cache/cache_tier.hpp
@@ -165,6 +165,10 @@ class CacheTier : public Storage::IStorage
     StorageResult<bool> CheckIfFileExists(const std::filesystem::path& fuse_path) const override;
     StorageResult<struct stat> GetAttributes(const std::filesystem::path& fuse_path) const override;
 
+    StorageResult<void> SetPermissions(const fs::path& relative_path, mode_t mode) override;
+
+    StorageResult<void> SetOwner(const fs::path& relative_path, uid_t uid, gid_t gid) override;
+
     fs::path RelativeToAbsPath(const std::filesystem::path& fuse_path) const override;
 
     //

--- a/src/storage/i_storage.hpp
+++ b/src/storage/i_storage.hpp
@@ -21,6 +21,8 @@
 namespace DistributedCacheFS::Storage
 {
 
+namespace fs = std::filesystem;
+
 // Interface for a Cache Storage Tier
 class IStorage
 {
@@ -75,9 +77,12 @@ class IStorage
     ) = 0;
 
     virtual StorageResult<void> Move(
-        const std::filesystem::path& from_relative_path,
-        const std::filesystem::path& to_relative_path
+        const fs::path& from_relative_path, const fs::path& to_relative_path
     ) = 0;
+
+    virtual StorageResult<void> SetPermissions(const fs::path& relative_path, mode_t mode) = 0;
+
+    virtual StorageResult<void> SetOwner(const fs::path& relative_path, uid_t uid, gid_t gid) = 0;
 
     // Initialization / Shutdown
     virtual StorageResult<void> Initialize() = 0;

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -734,87 +734,94 @@ StorageResult<void> LocalStorage::CreateFile(
 {
     std::lock_guard<std::recursive_mutex> lock(storage_mutex_);
     spdlog::debug("LocalStorage::CreateFile({}, {:o})", relative_path.string(), mode);
+
     auto full_path = GetValidatedFullPath(relative_path);
-    if (full_path.empty()) {
-        spdlog::trace("LocalStorage::CreateFile -> InvalidPath");
+    if (full_path.empty())
         return std::unexpected(make_error_code(StorageErrc::InvalidPath));
-    }
-    auto parent = full_path.parent_path();
+
+    // Create parent directories if missing
     std::error_code ec;
-    std::filesystem::create_directories(parent, ec);
-    if (ec) {
+    std::filesystem::create_directories(full_path.parent_path(), ec);
+    if (ec)
         return std::unexpected(MapFilesystemError(ec, "create_file_parent"));
-    }
+
+    // Create & close empty file
     std::ofstream ofs(full_path, std::ios::binary | std::ios::trunc);
-    if (!ofs) {
+    if (!ofs)
         return std::unexpected(make_error_code(StorageErrc::IOError));
-    }
     ofs.close();
-    std::filesystem::perms perms = static_cast<std::filesystem::perms>(0);
-    if (mode & S_IRUSR)
-        perms |= std::filesystem::perms::owner_read;
-    if (mode & S_IWUSR)
-        perms |= std::filesystem::perms::owner_write;
-    if (mode & S_IRGRP)
-        perms |= std::filesystem::perms::group_read;
-    if (mode & S_IWGRP)
-        perms |= std::filesystem::perms::group_write;
-    if (mode & S_IROTH)
-        perms |= std::filesystem::perms::others_read;
-    if (mode & S_IWOTH)
-        perms |= std::filesystem::perms::others_write;
+
+    // Apply permissions incl. execute bits
+    std::filesystem::perms perms{};
+    auto add = [&](mode_t m, std::filesystem::perms p) {
+        if (mode & m)
+            perms |= p;
+    };
+    add(S_IRUSR, std::filesystem::perms::owner_read);
+    add(S_IWUSR, std::filesystem::perms::owner_write);
+    add(S_IXUSR, std::filesystem::perms::owner_exec);
+    add(S_IRGRP, std::filesystem::perms::group_read);
+    add(S_IWGRP, std::filesystem::perms::group_write);
+    add(S_IXGRP, std::filesystem::perms::group_exec);
+    add(S_IROTH, std::filesystem::perms::others_read);
+    add(S_IWOTH, std::filesystem::perms::others_write);
+    add(S_IXOTH, std::filesystem::perms::others_exec);
     std::filesystem::permissions(full_path, perms, ec);
-    if (ec) {
+    if (ec)
         return std::unexpected(MapFilesystemError(ec, "create_file_perm"));
-    }
+
+    // special bits
+    if (mode & (S_ISUID | S_ISGID | S_ISVTX))
+        if (::chmod(full_path.c_str(), mode) == -1)
+            return std::unexpected(make_error_code(ErrnoToStorageErrc(errno)));
+
     spdlog::trace("LocalStorage::CreateFile -> Success");
     return {};
 }
+
 StorageResult<void> LocalStorage::CreateDirectory(
     const std::filesystem::path& relative_path, mode_t mode
 )
 {
     std::lock_guard<std::recursive_mutex> lock(storage_mutex_);
     spdlog::debug("LocalStorage::CreateDirectory({}, {:o})", relative_path.string(), mode);
+
     auto full_path = GetValidatedFullPath(relative_path);
-    if (full_path.empty()) {
-        spdlog::trace("LocalStorage::CreateDirectory -> InvalidPath");
+    if (full_path.empty())
         return std::unexpected(make_error_code(StorageErrc::InvalidPath));
-    }
+
     std::error_code ec;
-    // Create directory and all parents
-    if (!fs::create_directories(full_path, ec) && ec) {
-        spdlog::error(
-            "LocalStorage::CreateDirectory: Failed to create directory '{}': {}",
-            full_path.string(), ec.message()
-        );
+    if (!std::filesystem::create_directories(full_path, ec) && ec)
         return std::unexpected(MapFilesystemError(ec, "create_directory"));
-    }
-    // Set permissions from mode
-    std::filesystem::perms perms = static_cast<std::filesystem::perms>(0);
-    if (mode & S_IRUSR)
-        perms |= std::filesystem::perms::owner_read;
-    if (mode & S_IWUSR)
-        perms |= std::filesystem::perms::owner_write;
-    if (mode & S_IRGRP)
-        perms |= std::filesystem::perms::group_read;
-    if (mode & S_IWGRP)
-        perms |= std::filesystem::perms::group_write;
-    if (mode & S_IROTH)
-        perms |= std::filesystem::perms::others_read;
-    if (mode & S_IWOTH)
-        perms |= std::filesystem::perms::others_write;
+
+    // Set directory permissions incl. execute/search bits
+    std::filesystem::perms perms{};
+    auto add = [&](mode_t m, std::filesystem::perms p) {
+        if (mode & m)
+            perms |= p;
+    };
+    add(S_IRUSR, std::filesystem::perms::owner_read);
+    add(S_IWUSR, std::filesystem::perms::owner_write);
+    add(S_IXUSR, std::filesystem::perms::owner_exec);
+    add(S_IRGRP, std::filesystem::perms::group_read);
+    add(S_IWGRP, std::filesystem::perms::group_write);
+    add(S_IXGRP, std::filesystem::perms::group_exec);
+    add(S_IROTH, std::filesystem::perms::others_read);
+    add(S_IWOTH, std::filesystem::perms::others_write);
+    add(S_IXOTH, std::filesystem::perms::others_exec);
     std::filesystem::permissions(full_path, perms, ec);
-    if (ec) {
-        spdlog::error(
-            "LocalStorage::CreateDirectory: Failed to set permissions on '{}': {}",
-            full_path.string(), ec.message()
-        );
+    if (ec)
         return std::unexpected(MapFilesystemError(ec, "create_directory_perm"));
-    }
+
+    // sticky / setgid on directories
+    if (mode & (S_ISGID | S_ISVTX))
+        if (::chmod(full_path.c_str(), mode) == -1)
+            return std::unexpected(make_error_code(ErrnoToStorageErrc(errno)));
+
     spdlog::trace("LocalStorage::CreateDirectory -> Success");
     return {};
 }
+
 StorageResult<void> LocalStorage::Move(
     const std::filesystem::path& from_relative_path, const std::filesystem::path& to_relative_path
 )
@@ -916,6 +923,75 @@ StorageResult<std::vector<std::pair<std::string, struct stat>>> LocalStorage::Li
     }
     spdlog::trace("LocalStorage::ListDirectory -> {} entries", entries.size());
     return entries;
+}
+
+StorageResult<void> LocalStorage::SetPermissions(
+    const std::filesystem::path& relative_path, mode_t mode
+)
+{
+    std::lock_guard<std::recursive_mutex> lock(storage_mutex_);
+    spdlog::debug("LocalStorage::SetPermissions({}, {:o})", relative_path.string(), mode);
+
+    auto full_path = GetValidatedFullPath(relative_path);
+    if (full_path.empty())
+        return std::unexpected(make_error_code(StorageErrc::InvalidPath));
+
+    // Convert POSIX mode → std::filesystem::perms (incl. execute bits)
+    std::filesystem::perms perms = std::filesystem::perms::none;
+    auto add                     = [&](mode_t m, std::filesystem::perms p) {
+        if (mode & m)
+            perms |= p;
+    };
+    add(S_IRUSR, std::filesystem::perms::owner_read);
+    add(S_IWUSR, std::filesystem::perms::owner_write);
+    add(S_IXUSR, std::filesystem::perms::owner_exec);
+    add(S_IRGRP, std::filesystem::perms::group_read);
+    add(S_IWGRP, std::filesystem::perms::group_write);
+    add(S_IXGRP, std::filesystem::perms::group_exec);
+    add(S_IROTH, std::filesystem::perms::others_read);
+    add(S_IWOTH, std::filesystem::perms::others_write);
+    add(S_IXOTH, std::filesystem::perms::others_exec);
+
+    std::error_code ec;
+    std::filesystem::permissions(full_path, perms, ec);
+    if (ec)
+        return std::unexpected(MapFilesystemError(ec, "chmod"));
+
+    /* Preserve special bits (set-uid, set-gid, sticky) via raw chmod */
+    if (mode & (S_ISUID | S_ISGID | S_ISVTX)) {
+        if (::chmod(full_path.c_str(), mode) == -1)
+            return std::unexpected(make_error_code(ErrnoToStorageErrc(errno)));
+    }
+
+    spdlog::trace("LocalStorage::SetPermissions -> Success for {}", full_path.string());
+    return {};
+}
+
+StorageResult<void> LocalStorage::SetOwner(
+    const std::filesystem::path& relative_path, uid_t uid, gid_t gid
+)
+{
+    std::lock_guard<std::recursive_mutex> lock(storage_mutex_);
+    spdlog::debug("LocalStorage::SetOwner({}, {}, {})", relative_path.string(), uid, gid);
+
+    auto full_path = GetValidatedFullPath(relative_path);
+    if (full_path.empty()) {
+        spdlog::error("LocalStorage::SetOwner: Invalid path {}", relative_path.string());
+        return std::unexpected(make_error_code(StorageErrc::InvalidPath));
+    }
+
+    // -1 for uid or gid means don't change
+    if (::chown(full_path.c_str(), uid, gid) == -1) {
+        int chown_errno = errno;
+        spdlog::error(
+            "LocalStorage::SetOwner failed for path {}: {}", full_path.string(),
+            std::strerror(chown_errno)
+        );
+        return std::unexpected(make_error_code(ErrnoToStorageErrc(chown_errno)));
+    }
+
+    spdlog::trace("LocalStorage::SetOwner -> Success for {}", full_path.string());
+    return {};
 }
 
 }  // namespace DistributedCacheFS::Storage

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -496,8 +496,8 @@ StorageResult<std::size_t> LocalStorage::Write(
     }
 
     // Capacity guard – reject if the growth would exceed max_size_bytes_
-    const off_t new_size   = std::max<off_t>(old_size, offset + static_cast<off_t>(data.size()));
-    const uint64_t growth  = (new_size > old_size) ? static_cast<uint64_t>(new_size - old_size) : 0;
+    const off_t new_size  = std::max<off_t>(old_size, offset + static_cast<off_t>(data.size()));
+    const uint64_t growth = (new_size > old_size) ? static_cast<uint64_t>(new_size - old_size) : 0;
 
     if (stats_.UsesSizeTracking() && growth > 0) {
         auto avail_res = GetAvailableBytes();
@@ -506,8 +506,8 @@ StorageResult<std::size_t> LocalStorage::Write(
         }
         if (growth > *avail_res) {
             spdlog::warn(
-                "LocalStorage::Write: Out of space – need {} bytes, only {} bytes left.",
-                growth, *avail_res
+                "LocalStorage::Write: Out of space – need {} bytes, only {} bytes left.", growth,
+                *avail_res
             );
             return std::unexpected(make_error_code(StorageErrc::OutOfSpace));
         }
@@ -670,8 +670,8 @@ StorageResult<void> LocalStorage::Truncate(const std::filesystem::path& relative
         }
         if (growth > *avail_res) {
             spdlog::warn(
-                "LocalStorage::Truncate: Out of space – need {} bytes, only {} bytes left.",
-                growth, *avail_res
+                "LocalStorage::Truncate: Out of space – need {} bytes, only {} bytes left.", growth,
+                *avail_res
             );
             return std::unexpected(make_error_code(StorageErrc::OutOfSpace));
         }

--- a/src/storage/local_storage.hpp
+++ b/src/storage/local_storage.hpp
@@ -74,6 +74,10 @@ class LocalStorage : public IStorage
         const std::filesystem::path& to_relative_path
     ) override;
 
+    StorageResult<void> SetPermissions(const fs::path& relative_path, mode_t mode) override;
+
+    StorageResult<void> SetOwner(const fs::path& relative_path, uid_t uid, gid_t gid) override;
+
     StorageResult<void> Initialize() override;
     StorageResult<void> Shutdown() override;
 


### PR DESCRIPTION
This pull request adds support for `chmod` and `chown` operations in the FUSE layer and refactors the `CacheManager` and `CacheTier` classes to handle permission and ownership changes. It also introduces a helper for POSIX-like permission checks and improves error handling and logging throughout the FUSE operations. Below is a categorized summary of the most important changes:

### New Features
* Added `SetPermissions` and `SetOwner` methods to `CacheManager` and `CacheTier` to handle permission and ownership changes, including cache invalidation when necessary. (`src/cache/cache_manager.cpp` [[1]](diffhunk://#diff-71ca9c7876cf30bffaf2ea5e90796093b7c8153fdc935168f4bff791b44eb5f4R471-R564) `src/cache/cache_manager.hpp` [[2]](diffhunk://#diff-3e5782c925a6b455ef8aa540c5998802af46a367444014dbf05b0b181c484fccR104-R107) `src/cache/cache_tier.cpp` [[3]](diffhunk://#diff-ee7354235e23e9d680f98e28ba0d52223cf0024a3e3a7c2ea1d29e9c295374c3R327-R360) `src/cache/cache_tier.hpp` [[4]](diffhunk://#diff-602eb770f4d9536e37cfec377f39efd39ea6e7966317603ff214cf9bcdfd42d5R168-R171)
* Implemented `chmod` and `chown` FUSE operations to update file permissions and ownership in the distributed cache. (`src/fuse_operations.cpp` [src/fuse_operations.cppL214-R396](diffhunk://#diff-adb8052c16e4db28e80562db14ba0b0242623cf25271a2333ccf1cd9d8681a6dL214-R396))

### Refactoring
* Renamed `get_coordinator` to `get_manager` in the FUSE layer for better clarity and updated all references accordingly. (`src/fuse_operations.cpp` [src/fuse_operations.cppL23-R24](diffhunk://#diff-adb8052c16e4db28e80562db14ba0b0242623cf25271a2333ccf1cd9d8681a6dL23-R24))
* Simplified the `open` FUSE operation by restructuring `O_CREAT` handling and adding permission checks using a new helper function. (`src/fuse_operations.cpp` [src/fuse_operations.cppL214-R396](diffhunk://#diff-adb8052c16e4db28e80562db14ba0b0242623cf25271a2333ccf1cd9d8681a6dL214-R396))

### Helper Functions
* Introduced `permission_check_helper` to perform POSIX-like permission checks, ensuring proper access control in the FUSE layer. (`src/fuse_operations.cpp` [src/fuse_operations.cppR61-R143](diffhunk://#diff-adb8052c16e4db28e80562db14ba0b0242623cf25271a2333ccf1cd9d8681a6dR61-R143))

### Logging and Error Handling
* Enhanced logging for permission and ownership operations, including debug and trace logs for success and failure scenarios. (`src/cache/cache_manager.cpp` [[1]](diffhunk://#diff-71ca9c7876cf30bffaf2ea5e90796093b7c8153fdc935168f4bff791b44eb5f4R471-R564) `src/cache/cache_tier.cpp` [[2]](diffhunk://#diff-ee7354235e23e9d680f98e28ba0d52223cf0024a3e3a7c2ea1d29e9c295374c3R327-R360)

### Miscellaneous
* Added missing `unistd.h` include to support calls like `getgroups` in the new permission check helper. (`src/fuse_operations.cpp` [src/fuse_operations.cppR12](diffhunk://#diff-adb8052c16e4db28e80562db14ba0b0242623cf25271a2333ccf1cd9d8681a6dR12))