### PR TITLE
Update cache management and configuration settings

### DIFF
--- a/src/app_constants.hpp
+++ b/src/app_constants.hpp
@@ -24,7 +24,8 @@ constexpr std::string_view DEFAULT_MDNS_SERVICE_NAME = "_dcachefs._tcp";
 constexpr std::uint16_t DEFAULT_LISTEN_PORT          = 9876;
 
 // Filesystem
-constexpr double HEAT_REFRESH_PROBABILITY = 0.05;  // 5% of entries get passive heat refresh
+constexpr double DEFAULT_DECAY_CONSTANT = 0.02;  // % of heat to decay per second
+constexpr double HEAT_REFRESH_PROBABILITY = 0.50;  // % of entries to get passive heat refresh
 constexpr std::size_t HEAT_REFRESH_PERIOD = 128;   // run refresh after this many read hits
 
 // FUSE

--- a/src/config/config_types.hpp
+++ b/src/config/config_types.hpp
@@ -41,7 +41,7 @@ std::optional<spdlog::level::level_enum> StringToLogLevel(const std::string &lev
 //------------------------------------------------------------------------------//
 
 struct CacheSettings {
-    double decay_constant = 0.0001;  ///< Decay constant per second
+    double decay_constant = Constants::DEFAULT_DECAY_CONSTANT;
 
     bool isValid() const;
 };


### PR DESCRIPTION
- Introduced a mapping callback in CacheTier to notify CacheManager of item additions and removals.
- Enhanced TryPromoteItem method in CacheManager with improved logging for promotion attempts and failures.
- Updated RefreshRandomHeats method in CacheTier to utilize a snapshot of items for heat updates, improving efficiency.
- Adjusted decay constant in configuration to use the new default value.

Note:
In the future, cache heat recalculation (cooling) should be done on a separate thread with a custom message queue